### PR TITLE
Fix answer text color for dark mode

### DIFF
--- a/QuizForge.html
+++ b/QuizForge.html
@@ -16,6 +16,7 @@
     --bad:#dc2626;   /* red-600 */
     --btn1:#7c3aed;  /* violet-600 */
     --btn2:#06b6d4;  /* cyan-500 */
+    --choice-text:#1e40af; /* blue-800 */
   }
   @media (prefers-color-scheme: dark){
     :root{
@@ -77,7 +78,7 @@
 
   /* Custom radio pills */
   .choice{ position:relative; display:flex; align-items:center; gap:12px; padding:14px 16px; border-radius:16px;
-    border:1px solid #ffffff7a; background:#ffffffcc; color:var(--text);
+    border:1px solid #ffffff7a; background:#ffffffcc; color:var(--choice-text);
     box-shadow: 0 6px 14px rgba(0,0,0,.08);
     transition: box-shadow .25s ease, transform .05s ease, background .2s ease, border .2s ease;
   }


### PR DESCRIPTION
## Summary
- add `--choice-text` variable for answer text color
- ensure choice buttons use this darker color

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68891cae4c68832f883a575e403bb564