### PR TITLE
feat: expose premium helpers for node

### DIFF
--- a/app.js
+++ b/app.js
@@ -479,23 +479,39 @@ function buildPlanSummaryText(){
 }
 
 /* ====== Init ====== */
-window.addEventListener("DOMContentLoaded", async () => {
-  // Load data
-  state.company = await loadJSON("data/company.json", "fallback-company");
-  state.conditions = await loadJSON("data/conditions.json", "fallback-conditions");
-  state.objections = await loadJSON("data/objections.json", "fallback-objections");
+if (typeof window !== "undefined") {
+  window.addEventListener("DOMContentLoaded", async () => {
+    // Load data
+    state.company = await loadJSON("data/company.json", "fallback-company");
+    state.conditions = await loadJSON("data/conditions.json", "fallback-conditions");
+    state.objections = await loadJSON("data/objections.json", "fallback-objections");
 
-  // Brand visuals
-  $("#brandName").textContent = state.company.brand.name;
-  $("#brandTag").textContent = state.company.brand.tagline;
-  $("#brandLogo").src = state.company.brand.logo;
+    // Brand visuals
+    $("#brandName").textContent = state.company.brand.name;
+    $("#brandTag").textContent = state.company.brand.tagline;
+    $("#brandLogo").src = state.company.brand.logo;
 
-  // Slides + UI
-  Slides.init();
-  buildConditionsUI();
-  attachEvents();
-  syncGoalToggle();
+    // Slides + UI
+    Slides.init();
+    buildConditionsUI();
+    attachEvents();
+    syncGoalToggle();
 
-  // First compute
-  recompute();
-});
+    // First compute
+    recompute();
+  });
+}
+
+// Export helpers for Node/CommonJS consumers (e.g., unit tests)
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    baseRatePer1k,
+    ageFactor,
+    smokerFactor,
+    productFactor,
+    conditionsMultiplier,
+    riderCost,
+    computePremium,
+    solveDeathBenefit,
+  };
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// Node entry point re-exporting premium helper functions
+module.exports = require('./app.js');


### PR DESCRIPTION
## Summary
- guard browser-only initialization in `app.js`
- export premium helper functions for Node/CommonJS consumers
- add `index.js` entry point re-exporting app helpers

## Testing
- `node -e "const { computePremium } = require('./index.js'); const res = computePremium({deathBenefit:100000, age:35, sex:'M', policyType:'Term', smoker:'N', conditions:[], riders:[], policyFee:6, modalFactor:0.09, term:20, heightIn:70, weightLb:180}); console.log(res.billed.toFixed(2));"`


------
https://chatgpt.com/codex/tasks/task_e_68a40318f954832f8c474263afec94b3