### PR TITLE
feat: add calc button and plan interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,10 +191,7 @@
         </div>
         <div class="field">
           <label for="state">State</label>
-          <select id="state">
-            <option value="MI">MI</option><option value="NY">NY</option><option value="CA">CA</option>
-            <option value="FL">FL</option><option value="TX">TX</option><option value="OH">OH</option>
-          </select>
+          <select id="state"><!-- populated via JS --></select>
         </div>
         <div class="field">
           <label for="smoker">Smoker</label>
@@ -202,13 +199,11 @@
         </div>
         <div class="field">
           <label for="policyType">Policy Type</label>
-          <select id="policyType">
-            <option>Term</option><option>Whole</option><option>UL</option><option>IUL</option><option>GUL</option><option>Final Expense</option>
-          </select>
+          <select id="policyType"><!-- populated via JS --></select>
         </div>
         <div class="field">
           <label for="term">Term Length (Term)</label>
-          <select id="term"><option>10</option><option>15</option><option selected>20</option><option>25</option><option>30</option></select>
+          <select id="term"><!-- populated via JS --></select>
         </div>
         <fieldset class="switch">
           <legend>Coverage Goal</legend>
@@ -255,6 +250,10 @@
             <li><span>Adjusted Premium</span> <strong id="adjPrem">$—</strong></li>
             <li><span>Key Multipliers</span> <strong id="multis">—</strong></li>
           </ul>
+        </div>
+
+        <div class="actions">
+          <button type="button" id="calcBtn" class="btn">Calculate Premium/Death Benefit</button>
         </div>
       </form>
     </aside>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// Node entry point re-exporting premium helper functions
+module.exports = require('./app.js');

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+rem Start a static server for the presentation app
+npx http-server . -p 8080 -c-1

--- a/styles.css
+++ b/styles.css
@@ -59,6 +59,7 @@ img{max-width:100%; display:block}
 .plan header{display:flex; justify-content:space-between; align-items:center}
 .plan .badge{background:color-mix(in srgb, var(--primary), #000 10%); color:#fff; padding:6px 10px; border-radius:999px; font-weight:800}
 .plan .price{font-size:28px; font-weight:900}
+.plan.selected{outline:3px solid var(--primary)}
 .kv{list-style:none; padding:0; margin:10px 0}
 .kv li{display:flex; justify-content:space-between; gap:8px; padding:6px 0; border-bottom:1px dashed var(--border)}
 .kv li:last-child{border-bottom:none}
@@ -82,6 +83,8 @@ legend{font-weight:800}
 .cond-group label{display:flex; align-items:center; gap:8px; padding:6px 0}
 .muted{color:var(--muted)}
 .error{color:#dc2626; font-size:12px; min-height:16px}
+.actions{display:flex; justify-content:center;}
+
 
 /* Mobile: pin panel bottom 30% */
 @media (max-width: 860px){


### PR DESCRIPTION
## Summary
- add manual "Calculate Premium/Death Benefit" trigger in side panel
- highlight chosen plan and refresh breakdowns when comparing details
- show dynamic math for "How we calculated this" and expose rider/policy costs

## Testing
- `node -e "const { computePremium } = require('./index.js'); const res = computePremium({deathBenefit:100000, age:35, sex:'M', policyType:'Term', smoker:'N', conditions:[], riders:[], policyFee:6, modalFactor:0.09, term:20, heightIn:70, weightLb:180}); console.log(res.billed.toFixed(2));"`


------
https://chatgpt.com/codex/tasks/task_e_68a40318f954832f8c474263afec94b3