### PR TITLE
Add input validation and error handling for plan calculator

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,6 +254,7 @@
 
         <div class="actions">
           <button type="button" id="calcBtn" class="btn">Calculate Premium/Death Benefit</button>
+          <div class="error" id="inputErr" aria-live="polite"></div>
         </div>
       </form>
     </aside>


### PR DESCRIPTION
## Summary
- validate age, coverage goal, and necessary premium/benefit inputs
- handle missing data by displaying N/A plan prices
- show input errors and guard recompute logic with try/catch

## Testing
- `node -e "require('./app.js'); console.log('loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_68a412fb54a4832fad0441d611ac1536